### PR TITLE
BB-1834 Fix 'Calling Set on Destroyed Object' for tooltip

### DIFF
--- a/addon/components/bs-contextual-help.js
+++ b/addon/components/bs-contextual-help.js
@@ -733,7 +733,7 @@ export default Component.extend({
     }
   },
 
-  willRemoveElement() {
+  willDestroyElement() {
     this._super(...arguments);
     this.removeListeners();
   },


### PR DESCRIPTION
The issue is reported [here](https://github.com/kaliber5/ember-bootstrap/issues/350) and fixed only for new API. This should fix it for our API. 